### PR TITLE
Addressing the current needs for installing the agent

### DIFF
--- a/NewRelicWindowsAzure.nuspec
+++ b/NewRelicWindowsAzure.nuspec
@@ -26,6 +26,7 @@ https://support.newrelic.com/help/kb/dotnet/installing-the-net-agent-on-azure</d
   </metadata>
   <files>
     <file src="content\NewRelicAgent_x64_2.0.8.4.msi" target="content\NewRelicAgent_x64_2.0.8.4.msi" />
+    <file src="content\startup.cmd" target="content\startup.cmd" />
     <file src="tools\install.ps1" target="tools\install.ps1" />
   </files>
 </package>

--- a/NewRelicWindowsAzure.nuspec
+++ b/NewRelicWindowsAzure.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.0.0.3</version>
+    <version>1.0.0.9</version>
     <authors>Mike Cousins</authors>
     <owners />
     <licenseUrl>http://newrelic.com</licenseUrl>
@@ -25,8 +25,10 @@ https://support.newrelic.com/help/kb/dotnet/installing-the-net-agent-on-azure</d
     <summary>Includes the latest New Relic x64 installer, so that you can easily include New Relic in your Azure deployment.</summary>
   </metadata>
   <files>
+    <file src="content\newrelic.cmd" target="content\newrelic.cmd" />
     <file src="content\NewRelicAgent_x64_2.0.8.4.msi" target="content\NewRelicAgent_x64_2.0.8.4.msi" />
-    <file src="content\startup.cmd" target="content\startup.cmd" />
+    <file src="content\web.config.transform" target="content\web.config.transform" />
     <file src="tools\install.ps1" target="tools\install.ps1" />
+    <file src="tools\uninstall.ps1" target="tools\uninstall.ps1" />
   </files>
 </package>

--- a/NewRelicWindowsAzure.nuspec
+++ b/NewRelicWindowsAzure.nuspec
@@ -11,17 +11,19 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Installing New Relic on Windows Azure is a bit of a pain so I’ve created a NuGet package for it to make it dead easy. I’ll keep it updated with the latest NewRelic releases.
 
-Make sure you go to New Relic first to sign up and get your key. Performance monitoring will never be the same after you do!
+Make sure you go to New Relic first to sign up and get your key at http://newrelic.com. Performance monitoring will never be the same after you do!
 
-http://newrelic.com
+The package is available through your NuGet package manager and on the web at http://nuget.org/packages/NewRelicWindowsAzure
 
-The package will be available through your NuGet package manager. You can view it on the web as well:
+Set up:
+1. install-package NewRelicWindowsAzure
+2. Open the newrelic.cmd file in your projects root and replace the text "REPLACE_WITH_LICENSE_KEY" with your license key.
+3. Modify the web.config key "NewRelic.AppName" to use whatever custom name you want and deploy your application.
 
-http://nuget.org/List/Packages/NewRelicWindowsAzure 
+Visit http://rpm.newrelic.com after your package deploy is complete to see your performance metrics.
 
-Once you install the NuGet package you will need to follow these instructions to finish your setup before depolyment:
-
-https://support.newrelic.com/help/kb/dotnet/installing-the-net-agent-on-azure</description>
+For more information on what this package is doing go to: https://support.newrelic.com/help/kb/dotnet/installing-the-net-agent-on-azure
+</description>
     <summary>Includes the latest New Relic x64 installer, so that you can easily include New Relic in your Azure deployment.</summary>
   </metadata>
   <files>

--- a/content/newrelic.cmd
+++ b/content/newrelic.cmd
@@ -1,5 +1,5 @@
 REM Update this variable to the current installer name.
-SET NR_INSTALLER_NAME=NewRelicAgent_REPLACE_WITH_THE_EXACT_INSTALLER_NAME.msi
+SET NR_INSTALLER_NAME=NewRelicAgent_x64_2.0.8.4.msi
 
 REM Update with your license key
 SET LICENSE_KEY=REPLACE_WITH_LICENSE_KEY

--- a/content/startup.cmd
+++ b/content/startup.cmd
@@ -1,0 +1,42 @@
+REM Update this variable to the current installer name.
+SET NR_INSTALLER_NAME=NewRelicAgent_REPLACE_WITH_THE_EXACT_INSTALLER_NAME.msi
+
+REM Update with your license key
+SET LICENSE_KEY=REPLACE_WITH_LICENSE_KEY
+
+SETLOCAL EnableExtensions
+
+if defined NEWRELIC_HOME GOTO NR_ALREADY_INSTALLED
+if defined COR_ENABLE_PROFILING GOTO PROFILER_ALREADY_ENABLED
+if NOT exist %NR_INSTALLER_NAME% GOTO MISSING_INSTALLER
+    
+REM Run the agent installer
+%NR_INSTALLER_NAME% /quiet NR_LICENSE_KEY=%LICENSE_KEY% >> d:\nr.log
+
+REM Get the NEWRELIC_HOME environment variable value and set it in NR_HOME
+FOR /F "skip=2 tokens=3*" %%A IN ('REG QUERY "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v NEWRELIC_HOME 2^>nul') DO SET NR_HOME="%%A %%B"
+
+REM Uncomment the line below if you want to copy a custom newrelic.xml file into your instance
+REM copy /Y newrelic.xml %NR_HOME% >> d:\nr.log
+
+REM Uncomment the line below to copy custom instrumentation into the agent directory.
+REM copy /y CustomInstrumentation.xml %NR_HOME%\extensions >> d:\nr.log
+
+REM Restart the instance.  The worker process will be instrumented the next time it starts.
+SHUTDOWN /r /c "Reboot after installing the New Relic .NET Agent" /t 0
+
+GOTO END
+
+:MISSING_INSTALLER
+ECHO Unable to find %NR_INSTALLER_NAME% >> d:\nr.log
+GOTO END
+
+:PROFILER_ALREADY_ENABLED
+ECHO A profiler is already enabled.  Skipping the New Relic Agent installation. >> d:\nr.log
+GOTO END
+
+:NR_ALREADY_INSTALLED
+ECHO NEWRELIC_HOME is already defined.  Skipping the New Relic Agent installation. >> d:\nr.log
+GOTO END
+
+:END

--- a/content/web.config.transform
+++ b/content/web.config.transform
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <appSettings>
+    <add key="NewRelic.AppName" value="My Azure App"/>
+  </appSettings>
+</configuration>

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -2,3 +2,7 @@ param($installPath, $toolsPath, $package, $project)
 $newrelicMsi = $project.ProjectItems.Item("NewRelicAgent_x64_2.0.8.4.msi")
 $copyToOutput = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
 $copyToOutput.Value = 1
+
+$newrelicMsi = $project.ProjectItems.Item("startup.cmd")
+$copyToOutput = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
+$copyToOutput.Value = 1

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,8 +1,45 @@
 param($installPath, $toolsPath, $package, $project)
+
 $newrelicMsi = $project.ProjectItems.Item("NewRelicAgent_x64_2.0.8.4.msi")
 $copyToOutput = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
 $copyToOutput.Value = 1
 
-$newrelicMsi = $project.ProjectItems.Item("startup.cmd")
+$newrelicMsi = $project.ProjectItems.Item("newrelic.cmd")
 $copyToOutput = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
 $copyToOutput.Value = 1
+
+$filepath = $project.ProjectName + '.Azure\ServiceDefinition.csdef'
+$ServiceDefinitionConfig = $installPath.Replace("packages\NewRelicWindowsAzure.1.0.0.4", $filepath)
+
+Write-Host $ServiceDefinitionConfig
+ 
+[xml] $xml = gc $ServiceDefinitionConfig
+
+$startupNode = $xml.CreateElement('Startup','http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition')
+
+$newRelicTaskNode = $xml.CreateElement('Task','http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition')
+$newRelicTaskNode.SetAttribute('commandLine','newrelic.cmd')
+$newRelicTaskNode.SetAttribute('executionContext','elevated')
+$newRelicTaskNode.SetAttribute('taskType','simple')
+
+$startupNode.AppendChild($newRelicTaskNode)
+
+$modified = $xml.ServiceDefinition.WebRole.StartUp
+
+if($modified -eq $null){
+	$modified = $xml.ServiceDefinition.WebRole
+	$modified.PrependChild($startupNode)
+}
+else{
+	$nodeExists = $false
+	foreach ($i in $xml.ServiceDefinition.WebRole.Startup.Task){
+   		if ($i.commandLine -eq 'newrelic.cmd'){
+			$nodeExists = $true
+		}
+	}
+	if($NewRelicTask -eq $null -and !$nodeExists){
+		$modified.AppendChild($newRelicTaskNode)
+	}
+}
+
+$xml.Save($ServiceDefinitionConfig);

--- a/tools/uninstall.ps1
+++ b/tools/uninstall.ps1
@@ -1,0 +1,16 @@
+param($installPath, $toolsPath, $package, $project)
+
+$filepath = $project.ProjectName + '.Azure\ServiceDefinition.csdef'
+$ServiceDefinitionConfig = $installPath.Replace("packages\NewRelicWindowsAzure.1.0.0.4", $filepath)
+ 
+[xml] $xml = gc $ServiceDefinitionConfig
+
+$startupnode = $xml.ServiceDefinition.WebRole.Startup
+if($startupnode.ChildNodes.Count -gt 0){
+	$node = $xml.ServiceDefinition.WebRole.Startup.Task | where { $_.commandLine -eq "newrelic.cmd" }
+	[Void]$node.ParentNode.RemoveChild($node)
+	if($startupnode.ChildNodes.Count -eq 0){
+		[Void]$startupnode.ParentNode.RemoveChild($startupnode)
+	}
+	$xml.Save($ServiceDefinitionConfig)
+}


### PR DESCRIPTION
I added the cmd file from : https://newrelic.com/docs/dotnet/installing-the-net-agent-on-azure and the powershell to do a copy always.  Double and triple checked paths.  

I have not yet figured out how to unit test the package - I might create a branch and try out some pester / powershell just for assurance.

Also want to add a parameterized install for this step so that the user can enter in their own key and replace ""NewRelicAgent_REPLACE_WITH_THE_EXACT_INSTALLER_NAME" with a dynamic value - though I do like your idea about renaming the file or we could do a lazy fetch for the file - if missing go get latest. not sure yet.
