### PR TITLE
Removed the need for static versions and install paths. Also added a prompt for the use to enter in their new relic key

### DIFF
--- a/NewRelicWindowsAzure.nuspec
+++ b/NewRelicWindowsAzure.nuspec
@@ -6,6 +6,7 @@
     <owners />
     <licenseUrl>http://newrelic.com</licenseUrl>
     <projectUrl>http://blog.mikecousins.com/2011/08/31/new-relic-windows-azure-package-for-nuget/</projectUrl>
+    <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <id>NewRelicWindowsAzure</id>
     <title>New Relic x64 for Windows Azure</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -22,8 +23,7 @@ Set up:
 
 Visit http://rpm.newrelic.com after your package deploy is complete to see your performance metrics.
 
-For more information on what this package is doing go to: https://support.newrelic.com/help/kb/dotnet/installing-the-net-agent-on-azure
-</description>
+For more information on what this package is doing go to: https://support.newrelic.com/help/kb/dotnet/installing-the-net-agent-on-azure</description>
     <summary>Includes the latest New Relic x64 installer, so that you can easily include New Relic in your Azure deployment.</summary>
   </metadata>
   <files>

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,31 +1,44 @@
 param($installPath, $toolsPath, $package, $project)
 
-$newrelicMsi = $project.ProjectItems.Item("NewRelicAgent_x64_2.0.8.4.msi")
-$copyToOutput = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
-$copyToOutput.Value = 1
+$newrelicMsiFileName = "NewRelicAgent_x64_2.0.8.4.msi"
+$newrelicCmdFileName = "newrelic.cmd"
 
-$newrelicMsi = $project.ProjectItems.Item("newrelic.cmd")
-$copyToOutput = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
-$copyToOutput.Value = 1
+$licenseKey = Read-Host "Please enter in your New Relic license key (optional)"
 
-$filepath = $project.ProjectName + '.Azure\ServiceDefinition.csdef'
-$ServiceDefinitionConfig = $installPath.Replace("packages\NewRelicWindowsAzure.1.0.0.4", $filepath)
+#Modify NewRelic.msi and NewRelic.cmd so that they will be copy always
+$newrelicMsi = $project.ProjectItems.Item($newrelicMsiFileName)
+$copyToOutputMsi = $newrelicMsi.Properties.Item("CopyToOutputDirectory")
+$copyToOutputMsi.Value = 1
 
-Write-Host $ServiceDefinitionConfig
- 
+$newrelicCmd = $project.ProjectItems.Item($newrelicCmdFileName)
+$copyToOutputCmd = $newrelicCmd.Properties.Item("CopyToOutputDirectory")
+$copyToOutputCmd.Value = 1
+
+#Modify NewRelic.cmd to accept the user's license key input 
+if($licenseKey.Length -gt 0){
+	$newrelicCmdFile = $newrelicCmd.Properties.Item("FullPath").Value
+	$fileContent =  Get-Content $newrelicCmdFile | Foreach-Object {$_ -replace 'REPLACE_WITH_LICENSE_KEY', $licenseKey}
+	Set-Content -Value $fileContent -Path $newrelicCmdFile
+}
+else{
+	Write-Host "No Key was provided, please make sure to edit the newrelic.cmd file and add a valid New Relic license key"
+}
+
+#Modify the service config - adding a new Startup task to run the newrelic.cmd
+$svcConfigFile = $DTE.Solution.Projects|Select-Object -Expand ProjectItems|Where-Object{$_.Name -eq 'ServiceDefinition.csdef'}
+$ServiceDefinitionConfig = $svcConfigFile.Properties.Item("FullPath").Value
 [xml] $xml = gc $ServiceDefinitionConfig
 
+#Create startup and newrelic task nodes
 $startupNode = $xml.CreateElement('Startup','http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition')
-
 $newRelicTaskNode = $xml.CreateElement('Task','http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition')
-$newRelicTaskNode.SetAttribute('commandLine','newrelic.cmd')
+$newRelicTaskNode.SetAttribute('commandLine',$newrelicCmdFileName)
 $newRelicTaskNode.SetAttribute('executionContext','elevated')
 $newRelicTaskNode.SetAttribute('taskType','simple')
-
 $startupNode.AppendChild($newRelicTaskNode)
 
-$modified = $xml.ServiceDefinition.WebRole.StartUp
 
+$modified = $xml.ServiceDefinition.WebRole.StartUp
 if($modified -eq $null){
 	$modified = $xml.ServiceDefinition.WebRole
 	$modified.PrependChild($startupNode)
@@ -33,7 +46,7 @@ if($modified -eq $null){
 else{
 	$nodeExists = $false
 	foreach ($i in $xml.ServiceDefinition.WebRole.Startup.Task){
-   		if ($i.commandLine -eq 'newrelic.cmd'){
+   		if ($i.commandLine -eq $newrelicCmdFileName){
 			$nodeExists = $true
 		}
 	}
@@ -41,5 +54,6 @@ else{
 		$modified.AppendChild($newRelicTaskNode)
 	}
 }
-
 $xml.Save($ServiceDefinitionConfig);
+
+Write-Host "Package install is complete"

--- a/tools/uninstall.ps1
+++ b/tools/uninstall.ps1
@@ -1,8 +1,8 @@
 param($installPath, $toolsPath, $package, $project)
 
-$filepath = $project.ProjectName + '.Azure\ServiceDefinition.csdef'
-$ServiceDefinitionConfig = $installPath.Replace("packages\NewRelicWindowsAzure.1.0.0.4", $filepath)
- 
+#Modify the service config - removing the Startup task to run the newrelic.cmd
+$svcConfigFile = $DTE.Solution.Projects|Select-Object -Expand ProjectItems|Where-Object{$_.Name -eq 'ServiceDefinition.csdef'}
+$ServiceDefinitionConfig = $svcConfigFile.Properties.Item("FullPath").Value
 [xml] $xml = gc $ServiceDefinitionConfig
 
 $startupnode = $xml.ServiceDefinition.WebRole.Startup


### PR DESCRIPTION
- Prompt user for new relic key (currently only works when you install from package manager console and user for some reason cannot copy and paste into the console during prompt)
- Modified the way we pull back file paths to use the DTE API - which is far more stable than string / path dissection (install.ps1 and uninstall.ps1
- Added newrelic icon to the nuspec
- refactored and cleaned up the powershell to remove redundancy and closed loops
