### PR TITLE
Version # wrong in .cmd file

### DIFF
--- a/content/newrelic.cmd
+++ b/content/newrelic.cmd
@@ -1,5 +1,5 @@
 REM Update this variable to the current installer name.
-SET NR_INSTALLER_NAME=NewRelicAgent_x64_2.0.8.4.msi
+SET NR_INSTALLER_NAME=NewRelicAgent_x64_2.0.9.15.msi
 
 REM Update with your license key
 SET LICENSE_KEY=REPLACE_WITH_LICENSE_KEY


### PR DESCRIPTION
Rethinking this once I get a bit of time to work on this - static strings and version numbers are just a bad way to do this.
